### PR TITLE
Uniforms: fix path error

### DIFF
--- a/.hemtt/launch.toml
+++ b/.hemtt/launch.toml
@@ -16,7 +16,7 @@ parameters = [
     "-noPauseAudio"
 ]
 
-#mission = "ttt_test.VR"
+mission = "ttt_test.VR"
 #mission = "ttt_test.Malden"
 
 

--- a/addons/uniforms/CfgWeapons.hpp
+++ b/addons/uniforms/CfgWeapons.hpp
@@ -162,7 +162,7 @@ class CfgWeapons {
     class ttt_Uniform_Base_BW : U_B_CombatUniform_mcam {
         scope = 0;
         displayName = "Tactical Training Team";
-        picture = "z\ttt\addons\uniforms\data\ttt_uniform_icon_bw.paa";
+        picture = QPATHTOF(data\ttt_uniform_icon_bw.paa);
         model = "\A3\characters_f\Common\Suitpacks\suitpack_universal_F";
         
         class ItemInfo : ItemInfo


### PR DESCRIPTION
**When merged this pull request will:**

- add QPATHTOF macro to fix path error
- removed unneeded entries in config

### IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Remove {changes}`.