### PR TITLE
compat_vanilla - added float to helis, update authors and required addons

### DIFF
--- a/addons/compat_vanilla_vehicles/CfgVehicles.hpp
+++ b/addons/compat_vanilla_vehicles/CfgVehicles.hpp
@@ -39,4 +39,11 @@ class CfgVehicles {
         mass = 50;
     };
 
+    // Make vanilla Chinook and EH302 (IDAP/FIA transport heli) float on water. 
+    // Matches CUP Chinook/CH-53e and other heavy lift helos.  
+    // Direction on BIS method from Steam Workshop user "crub"
+    class Helicopter_Base_H;
+    class Heli_Transport_03_base_F: Helicopter_Base_H {waterLeakiness=0.1;};
+    class Heli_Transport_02_base_F: Helicopter_Base_H {waterLeakiness=0.1;};
+
 };

--- a/addons/compat_vanilla_vehicles/config.cpp
+++ b/addons/compat_vanilla_vehicles/config.cpp
@@ -5,13 +5,19 @@ class CfgPatches {
         // Meta information for editor
         name = COMPONENT_NAME;
         author = ECSTRING(main,TacticalTrainingTeam);
+        authors[] = {"PabstMirror", "AACO", "Andx"};
         url = ECSTRING(main,URL);
 
         // Minimum compatible version. When the game's version is lower, pop-up warning will appear when launching the game. Note: was disabled on purpose some time late into Arma 2: OA.
         requiredVersion = REQUIRED_VERSION;
         // Required addons, used for setting load order. (CfgPatches classname NOT PBO filename!)
         // When any of the addons are missing, a pop-up warning will appear when launching the game.
-        requiredAddons[] = { "ttt_main", "acre_main", "A3_Supplies_F_Enoch_Bags"};
+        requiredAddons[] = {
+            "ttt_main", 
+            "A3_Air_F_Heli_Heli_Transport_03",
+            "A3_Air_F_Heli_Heli_Transport_02",
+            "acre_main",
+            "A3_Supplies_F_Enoch_Bags"};
         // List of objects (CfgVehicles classes) contained in the addon. Important also for Zeus content (units and groups) unlocking.
         units[] = {};
         // List of weapons (CfgWeapons classes) contained in the addon.

--- a/addons/compat_vanilla_vehicles/readme.md
+++ b/addons/compat_vanilla_vehicles/readme.md
@@ -1,6 +1,17 @@
-# Vanilla Rucksäcke
+# Vanilla Vehicles
+
+## Rucksäcke
 
 Erhöht die Tragekapazität der Vanilla Funkrucksäcke damit zwei ACRE 117F rein passen und noch etwas Platz ist.
+
+## Hubschrauber
+
+Erlaubt dem Vanilla Chinook and EH302 (IDAP/FIA Transport Hubschrauber) auf dem Wasser zu schwimmen.
+
+Betroffene Classnames:
+
+- `Heli_Transport_03_base_F`
+- `Heli_Transport_02_base_F`
 
 ## Maintainers
 


### PR DESCRIPTION
# PULL REQUEST

**When merged this pull request will:**

- erlaubt Vanilla Hubschraubern `Heli_Transport_03_base_F` und `Heli_Transport_02_base_F` leichtes schwimmen im Wasser, analog zum Chinook aus CUP

## IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Remove {changes}`.
