### PR TITLE
compat_xeh_fix  - Add XEH fix for jbad, RnT 120mm

### DIFF
--- a/addons/compat_xeh_fix/compat_xeh_fix_jbad/CfgVehicles.hpp
+++ b/addons/compat_xeh_fix/compat_xeh_fix_jbad/CfgVehicles.hpp
@@ -1,0 +1,15 @@
+class CfgVehicles {
+    class Tank_F;
+    class Jbad_CraneCon: Tank_F { XEH_ENABLED; }; // "Contruction Crane" @Jbad
+
+    class PowerLines_Small_base_F;
+    class Jbad_Lamps_base_powerline: PowerLines_Small_base_F { XEH_ENABLED; }; // "" @Jbad
+
+    class Land_Jbad_PowLineB: Jbad_Lamps_base_powerline { XEH_ENABLED; }; // "" @Jbad
+
+    class Land_Jbad_PowLines_Conc2L;
+    class Land_Jbad_Pole_withlight: Land_Jbad_PowLines_Conc2L { XEH_ENABLED; }; // "" @Jbad
+    class Land_Jbad_Pole_Speaker: Land_Jbad_PowLines_Conc2L { XEH_ENABLED; }; // "" @Jbad
+    class Land_Jbad_Pole_1: Jbad_Lamps_base_powerline { XEH_ENABLED; }; // "" @Jbad
+};
+

--- a/addons/compat_xeh_fix/compat_xeh_fix_jbad/config.cpp
+++ b/addons/compat_xeh_fix/compat_xeh_fix_jbad/config.cpp
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class SUBADDON {
+        // Use meta information from specified addon. Used to avoid repeated declarations.
+        addonRootClass = QUOTE(ADDON);
+        
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"Jbad_ConstructionCrane","Jbad_Misc_Powerline"};
+        // Optional. If this is 1, if any of requiredAddons[] entry is missing in your game the entire config will be ignored and return no error (but in rpt) so useful to make a compat Mod (Since Arma 3 2.14)
+        skipWhenMissingDependencies = 1;   
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgVehicles.hpp"

--- a/addons/compat_xeh_fix/compat_xeh_fix_jbad/readme.md
+++ b/addons/compat_xeh_fix/compat_xeh_fix_jbad/readme.md
@@ -1,0 +1,5 @@
+# XEH Fix - JBAD
+
+## Maintainer
+
+- Andx

--- a/addons/compat_xeh_fix/compat_xeh_fix_jbad/script_component.hpp
+++ b/addons/compat_xeh_fix/compat_xeh_fix_jbad/script_component.hpp
@@ -1,4 +1,4 @@
-#define SUBCOMPONENT pbw
-#define SUBCOMPONENT_BEAUTIFIED PBW
+#define SUBCOMPONENT jbad
+#define SUBCOMPONENT_BEAUTIFIED JBAD
 
 #include "..\script_component.hpp"

--- a/addons/compat_xeh_fix/compat_xeh_fix_jbad/script_component.hpp
+++ b/addons/compat_xeh_fix/compat_xeh_fix_jbad/script_component.hpp
@@ -1,0 +1,4 @@
+#define SUBCOMPONENT pbw
+#define SUBCOMPONENT_BEAUTIFIED PBW
+
+#include "..\script_component.hpp"

--- a/addons/compat_xeh_fix/compat_xeh_fix_rnt/CfgVehicles.hpp
+++ b/addons/compat_xeh_fix/compat_xeh_fix_rnt/CfgVehicles.hpp
@@ -4,5 +4,7 @@ class CfgVehicles {
 
     class HMG_01_high_base_F;
     class rnt_mg3_static: HMG_01_high_base_F { XEH_ENABLED; }; // "MG3 (Tripod)" @Redd_n_Tank_Vehicles
-};
 
+    class StaticMortar;
+    class Redd_Tank_M120_Tampella_Base: StaticMortar { XEH_ENABLED; }; // "Mortar" @M120_Tampella_ACE_CSW
+};

--- a/addons/compat_xeh_fix/readme.md
+++ b/addons/compat_xeh_fix/readme.md
@@ -10,6 +10,7 @@ Enthält SUBCOMPONENT für:
 - FIR AWS
 - Vanilla
 - Breach
+- JBAD
 
 ## Referenzen
 


### PR DESCRIPTION
# PULL REQUEST

**When merged this pull request will:**

- title
- fixes:
```
23:28:51 [CBA] (xeh) WARNING: Jbad_CraneCon does not support Extended Event Handlers! Addon: @Jbad
23:28:51 [CBA] (xeh) WARNING: Jbad_Lamps_base_powerline does not support Extended Event Handlers! Addon: @Jbad
23:28:51 [CBA] (xeh) WARNING: Land_Jbad_PowLineB does not support Extended Event Handlers! Addon: @Jbad
23:28:51 [CBA] (xeh) WARNING: Land_Jbad_Pole_withlight does not support Extended Event Handlers! Addon: @Jbad
23:28:51 [CBA] (xeh) WARNING: Land_Jbad_Pole_Speaker does not support Extended Event Handlers! Addon: @Jbad
23:28:51 [CBA] (xeh) WARNING: Land_Jbad_Pole_1 does not support Extended Event Handlers! Addon: @Jbad
```

## IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Remove {changes}`.
