### PR TITLE
general - remove unused stringtables

### DIFF
--- a/addons/advancedtowing/stringtable.xml
+++ b/addons/advancedtowing/stringtable.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project name="ttt">
-    <Package name="Advancedtowing"></Package>
-</Project>

--- a/addons/compat_3cb_vehicles/stringtable.xml
+++ b/addons/compat_3cb_vehicles/stringtable.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project name="ttt">
-    <Package name="Compat_3cb_Vehicles"></Package>
-</Project>


### PR DESCRIPTION
# PULL REQUEST

**When merged this pull request will:**

- title
- fixes error in stringtable validator
```sqf
Checking addons\advancedtowing\stringtable.xml:
  ERROR: Incorrect number of indenting spaces on line 4, currently 0, should be 4.
Found 1 error(s).
Checking addons\compat_3cb_vehicles\stringtable.xml:
  ERROR: Incorrect number of indenting spaces on line 4, currently 0, should be 4.
Found 1 error(s).
```
## IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Remove {changes}`.
