### PR TITLE
compat_rhs - Change call

### DIFF
--- a/addons/compat_rhs/CfgEventhandlers.hpp
+++ b/addons/compat_rhs/CfgEventhandlers.hpp
@@ -18,6 +18,6 @@ class Extended_PostInit_EventHandlers {
 
 class Extended_SlotItemChanged_Eventhandlers {
     class CAManBase {
-        GVAR(SlotItemChanged) = QUOTE(_this call FUNC(handleSlotItemChanged););
+        GVAR(SlotItemChanged) = QUOTE( call FUNC(handleSlotItemChanged););
     };
 };


### PR DESCRIPTION
# PULL REQUEST

**When merged this pull request will:**

- removes `_this`

Fixes:
```bash
help[L-C13]: Unnecessary `_this` in `call`
   ┌─ addons/compat_rhs/CfgEventhandlers.hpp:21:33
   │
21 │         GVAR(SlotItemChanged) = QUOTE(_this call FUNC(handleSlotItemChanged););
   │                                 ^
   │
   = note: `call` inherits `_this` from the calling scope
   = help: Remove `_this` from the call
```

## IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Remove {changes}`.
- Component folder has a README.md explaining the component.
