### PR TITLE
tools - change math lint to pedantic and disable pedantic lints

### DIFF
--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -25,8 +25,11 @@ include = [
 [lints.sqf]
 command_case = true
 
+[lints.config.math_could_be_unquoted]
+enabled = "pedantic"
+
 [properties]
-url = "https://github.com/TacticalTrainingTeam/ttt_a3" # ToDo Change to TTT Repo URL
+url = "https://github.com/TacticalTrainingTeam/ttt_a3"
 
 [hemtt.signing]
 authority = "Tactical Training Team"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -60,7 +60,6 @@
 			},
 			"args": [
 				"check",
-				"-p",
 				"-v"
 			],
 			"problemMatcher": []

--- a/addons/compat_rhs/CfgEventhandlers.hpp
+++ b/addons/compat_rhs/CfgEventhandlers.hpp
@@ -18,6 +18,6 @@ class Extended_PostInit_EventHandlers {
 
 class Extended_SlotItemChanged_Eventhandlers {
     class CAManBase {
-        GVAR(SlotItemChanged) = QUOTE( call FUNC(handleSlotItemChanged););
+        GVAR(SlotItemChanged) = QUOTE(call FUNC(handleSlotItemChanged););
     };
 };


### PR DESCRIPTION
# PULL REQUEST

**When merged this pull request will:**

- title
- (fix small warning from another PR)

Removes loads of these helps:
https://hemtt.dev/analysis/config.html#math_could_be_unquoted

```
help[L-C12]: Math could be unquoted
   ┌─ addons/w_teleporter/Dialog.hpp:58:18
   │
58 │         sizeEx = QUOTE(SIZEEX);
   │                  ^ reducible to: 0.0375
   │
   = note: Could remove quotes to allow evaluation at build-time
```
Using macros makes it more readable instead of bare numbers.

## IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Remove {changes}`.
- Component folder has a README.md explaining the component.
