### PR TITLE
insignias_tagging - Add TTT emblems to ace tagging

### DIFF
--- a/addons/insignias/insignias_tagging/CfgTags.hpp
+++ b/addons/insignias/insignias_tagging/CfgTags.hpp
@@ -99,11 +99,11 @@ class ACE_Tags {
     };
 
     class insignia_grey {
-        displayName = ECSTRING(insignias,grey_emblem_displayName);  // Name of your tag being displayed in the interaction menu
+        displayName = ECSTRING(insignias,grau_emblem_displayName);  // Name of your tag being displayed in the interaction menu
         requiredItem = "ACE_SpraypaintBlack";  // Required item to have in the inventory to be able to spray your tag (eg. `"ACE_SpraypaintBlack"`, `"ACE_SpraypaintRed"`, `"ACE_SpraypaintGreen"`, `"ACE_SpraypaintBlue"` or any custom item from `CfgWeapons`)
-        textures[] = {QPATHTOEF(insignias,data\grey.paa)};  // List of texture variations (one is randomly selected when tagging)
+        textures[] = {QPATHTOEF(insignias,data\grau.paa)};  // List of texture variations (one is randomly selected when tagging)
         materials[] = {}; // Optional: List of material variations (one is randomly selected). Keep empty if you don't need a custom material.
-        icon = QPATHTOEF(insignias,data\grey.paa);  // Icon being displayed in the interaction menu
+        icon = QPATHTOEF(insignias,data\grau.paa);  // Icon being displayed in the interaction menu
         //tagModel = "UserTexture1m_F"; // Optional: The 3D Model that will be spawned with the texture on it, can either be CfgVehicles classname or P3D file path.
     };
 };

--- a/addons/insignias/insignias_tagging/CfgTags.hpp
+++ b/addons/insignias/insignias_tagging/CfgTags.hpp
@@ -1,0 +1,109 @@
+class ACE_Tags {
+    class insignia_blue {
+        displayName = ECSTRING(insignias,blue_emblem_displayName);  // Name of your tag being displayed in the interaction menu
+        requiredItem = "ACE_SpraypaintBlue";  // Required item to have in the inventory to be able to spray your tag (eg. `"ACE_SpraypaintBlack"`, `"ACE_SpraypaintRed"`, `"ACE_SpraypaintGreen"`, `"ACE_SpraypaintBlue"` or any custom item from `CfgWeapons`)
+        textures[] = {QPATHTOEF(insignias,data\blau.paa)};  // List of texture variations (one is randomly selected when tagging)
+        materials[] = {}; // Optional: List of material variations (one is randomly selected). Keep empty if you don't need a custom material.
+        icon = QPATHTOEF(insignias,data\blau.paa);  // Icon being displayed in the interaction menu
+        //tagModel = "UserTexture1m_F"; // Optional: The 3D Model that will be spawned with the texture on it, can either be CfgVehicles classname or P3D file path.
+    };
+
+    class insignia_bronze {
+        displayName = ECSTRING(insignias,bronze_emblem_displayName);  // Name of your tag being displayed in the interaction menu
+        requiredItem = "ACE_SpraypaintYellow";  // Required item to have in the inventory to be able to spray your tag (eg. `"ACE_SpraypaintBlack"`, `"ACE_SpraypaintRed"`, `"ACE_SpraypaintGreen"`, `"ACE_SpraypaintBlue"` or any custom item from `CfgWeapons`)
+        textures[] = {QPATHTOEF(insignias,data\bronze.paa)};  // List of texture variations (one is randomly selected when tagging)
+        materials[] = {}; // Optional: List of material variations (one is randomly selected). Keep empty if you don't need a custom material.
+        icon = QPATHTOEF(insignias,data\bronze.paa);  // Icon being displayed in the interaction menu
+        //tagModel = "UserTexture1m_F"; // Optional: The 3D Model that will be spawned with the texture on it, can either be CfgVehicles classname or P3D file path.
+    };
+
+    class insignia_yellow {
+        displayName = ECSTRING(insignias,yellow_emblem_displayName);  // Name of your tag being displayed in the interaction menu
+        requiredItem = "ACE_SpraypaintYellow";  // Required item to have in the inventory to be able to spray your tag (eg. `"ACE_SpraypaintBlack"`, `"ACE_SpraypaintRed"`, `"ACE_SpraypaintGreen"`, `"ACE_SpraypaintBlue"` or any custom item from `CfgWeapons`)
+        textures[] = {QPATHTOEF(insignias,data\gelb.paa)};  // List of texture variations (one is randomly selected when tagging)
+        materials[] = {}; // Optional: List of material variations (one is randomly selected). Keep empty if you don't need a custom material.
+        icon = QPATHTOEF(insignias,data\gelb.paa);  // Icon being displayed in the interaction menu
+        //tagModel = "UserTexture1m_F"; // Optional: The 3D Model that will be spawned with the texture on it, can either be CfgVehicles classname or P3D file path.
+    };
+
+    class insignia_orange {
+        displayName = ECSTRING(insignias,orange_emblem_displayName);  // Name of your tag being displayed in the interaction menu
+        requiredItem = "ACE_SpraypaintYellow";  // Required item to have in the inventory to be able to spray your tag (eg. `"ACE_SpraypaintBlack"`, `"ACE_SpraypaintRed"`, `"ACE_SpraypaintGreen"`, `"ACE_SpraypaintBlue"` or any custom item from `CfgWeapons`)
+        textures[] = {QPATHTOEF(insignias,data\orange.paa)};  // List of texture variations (one is randomly selected when tagging)
+        materials[] = {}; // Optional: List of material variations (one is randomly selected). Keep empty if you don't need a custom material.
+        icon = QPATHTOEF(insignias,data\orange.paa);  // Icon being displayed in the interaction menu
+        //tagModel = "UserTexture1m_F"; // Optional: The 3D Model that will be spawned with the texture on it, can either be CfgVehicles classname or P3D file path.
+    };
+
+    class insignia_green {
+        displayName = ECSTRING(insignias,green_emblem_displayName);  // Name of your tag being displayed in the interaction menu
+        requiredItem = "ACE_SpraypaintGreen";  // Required item to have in the inventory to be able to spray your tag (eg. `"ACE_SpraypaintBlack"`, `"ACE_SpraypaintRed"`, `"ACE_SpraypaintGreen"`, `"ACE_SpraypaintBlue"` or any custom item from `CfgWeapons`)
+        textures[] = {QPATHTOEF(insignias,data\gruen.paa)};  // List of texture variations (one is randomly selected when tagging)
+        materials[] = {}; // Optional: List of material variations (one is randomly selected). Keep empty if you don't need a custom material.
+        icon = QPATHTOEF(insignias,data\gruen.paa);  // Icon being displayed in the interaction menu
+        //tagModel = "UserTexture1m_F"; // Optional: The 3D Model that will be spawned with the texture on it, can either be CfgVehicles classname or P3D file path.
+    };
+
+    class insignia_red {
+        displayName = ECSTRING(insignias,red_emblem_displayName);  // Name of your tag being displayed in the interaction menu
+        requiredItem = "ACE_SpraypaintRed";  // Required item to have in the inventory to be able to spray your tag (eg. `"ACE_SpraypaintBlack"`, `"ACE_SpraypaintRed"`, `"ACE_SpraypaintGreen"`, `"ACE_SpraypaintBlue"` or any custom item from `CfgWeapons`)
+        textures[] = {QPATHTOEF(insignias,data\rot.paa)};  // List of texture variations (one is randomly selected when tagging)
+        materials[] = {}; // Optional: List of material variations (one is randomly selected). Keep empty if you don't need a custom material.
+        icon = QPATHTOEF(insignias,data\rot.paa);  // Icon being displayed in the interaction menu
+        //tagModel = "UserTexture1m_F"; // Optional: The 3D Model that will be spawned with the texture on it, can either be CfgVehicles classname or P3D file path.
+    };
+
+    class insignia_violet {
+        displayName = ECSTRING(insignias,violet_emblem_displayName);  // Name of your tag being displayed in the interaction menu
+        requiredItem = "ACE_SpraypaintRed";  // Required item to have in the inventory to be able to spray your tag (eg. `"ACE_SpraypaintBlack"`, `"ACE_SpraypaintRed"`, `"ACE_SpraypaintGreen"`, `"ACE_SpraypaintBlue"` or any custom item from `CfgWeapons`)
+        textures[] = {QPATHTOEF(insignias,data\violet.paa)};  // List of texture variations (one is randomly selected when tagging)
+        materials[] = {}; // Optional: List of material variations (one is randomly selected). Keep empty if you don't need a custom material.
+        icon = QPATHTOEF(insignias,data\violet.paa);  // Icon being displayed in the interaction menu
+        //tagModel = "UserTexture1m_F"; // Optional: The 3D Model that will be spawned with the texture on it, can either be CfgVehicles classname or P3D file path.
+    };
+
+    class insignia_black {
+        displayName = ECSTRING(insignias,black_emblem_displayName);  // Name of your tag being displayed in the interaction menu
+        requiredItem = "ACE_SpraypaintBlack";  // Required item to have in the inventory to be able to spray your tag (eg. `"ACE_SpraypaintBlack"`, `"ACE_SpraypaintRed"`, `"ACE_SpraypaintGreen"`, `"ACE_SpraypaintBlue"` or any custom item from `CfgWeapons`)
+        textures[] = {QPATHTOEF(insignias,data\schwarz.paa)};  // List of texture variations (one is randomly selected when tagging)
+        materials[] = {}; // Optional: List of material variations (one is randomly selected). Keep empty if you don't need a custom material.
+        icon = QPATHTOEF(insignias,data\schwarz.paa);  // Icon being displayed in the interaction menu
+        //tagModel = "UserTexture1m_F"; // Optional: The 3D Model that will be spawned with the texture on it, can either be CfgVehicles classname or P3D file path.
+    };
+
+    class insignia_white {
+        displayName = ECSTRING(insignias,white_emblem_displayName);  // Name of your tag being displayed in the interaction menu
+        requiredItem = "ACE_SpraypaintWhite";  // Required item to have in the inventory to be able to spray your tag (eg. `"ACE_SpraypaintBlack"`, `"ACE_SpraypaintRed"`, `"ACE_SpraypaintGreen"`, `"ACE_SpraypaintBlue"` or any custom item from `CfgWeapons`)
+        textures[] = {QPATHTOEF(insignias,data\weiss.paa)};  // List of texture variations (one is randomly selected when tagging)
+        materials[] = {}; // Optional: List of material variations (one is randomly selected). Keep empty if you don't need a custom material.
+        icon = QPATHTOEF(insignias,data\weiss.paa);  // Icon being displayed in the interaction menu
+        //tagModel = "UserTexture1m_F"; // Optional: The 3D Model that will be spawned with the texture on it, can either be CfgVehicles classname or P3D file path.
+    };
+
+    class insignia_silver {
+        displayName = ECSTRING(insignias,silver_emblem_displayName);  // Name of your tag being displayed in the interaction menu
+        requiredItem = "ACE_SpraypaintWhite";  // Required item to have in the inventory to be able to spray your tag (eg. `"ACE_SpraypaintBlack"`, `"ACE_SpraypaintRed"`, `"ACE_SpraypaintGreen"`, `"ACE_SpraypaintBlue"` or any custom item from `CfgWeapons`)
+        textures[] = {QPATHTOEF(insignias,data\silber.paa)};  // List of texture variations (one is randomly selected when tagging)
+        materials[] = {}; // Optional: List of material variations (one is randomly selected). Keep empty if you don't need a custom material.
+        icon = QPATHTOEF(insignias,data\silber.paa);  // Icon being displayed in the interaction menu
+        //tagModel = "UserTexture1m_F"; // Optional: The 3D Model that will be spawned with the texture on it, can either be CfgVehicles classname or P3D file path.
+    };
+
+    class insignia_platinum {
+        displayName = ECSTRING(insignias,platinum_emblem_displayName);  // Name of your tag being displayed in the interaction menu
+        requiredItem = "ACE_SpraypaintWhite";  // Required item to have in the inventory to be able to spray your tag (eg. `"ACE_SpraypaintBlack"`, `"ACE_SpraypaintRed"`, `"ACE_SpraypaintGreen"`, `"ACE_SpraypaintBlue"` or any custom item from `CfgWeapons`)
+        textures[] = {QPATHTOEF(insignias,data\platinum.paa)};  // List of texture variations (one is randomly selected when tagging)
+        materials[] = {}; // Optional: List of material variations (one is randomly selected). Keep empty if you don't need a custom material.
+        icon = QPATHTOEF(insignias,data\platinum.paa);  // Icon being displayed in the interaction menu
+        //tagModel = "UserTexture1m_F"; // Optional: The 3D Model that will be spawned with the texture on it, can either be CfgVehicles classname or P3D file path.
+    };
+
+    class insignia_grey {
+        displayName = ECSTRING(insignias,grey_emblem_displayName);  // Name of your tag being displayed in the interaction menu
+        requiredItem = "ACE_SpraypaintBlack";  // Required item to have in the inventory to be able to spray your tag (eg. `"ACE_SpraypaintBlack"`, `"ACE_SpraypaintRed"`, `"ACE_SpraypaintGreen"`, `"ACE_SpraypaintBlue"` or any custom item from `CfgWeapons`)
+        textures[] = {QPATHTOEF(insignias,data\grey.paa)};  // List of texture variations (one is randomly selected when tagging)
+        materials[] = {}; // Optional: List of material variations (one is randomly selected). Keep empty if you don't need a custom material.
+        icon = QPATHTOEF(insignias,data\grey.paa);  // Icon being displayed in the interaction menu
+        //tagModel = "UserTexture1m_F"; // Optional: The 3D Model that will be spawned with the texture on it, can either be CfgVehicles classname or P3D file path.
+    };
+};

--- a/addons/insignias/insignias_tagging/config.cpp
+++ b/addons/insignias/insignias_tagging/config.cpp
@@ -1,0 +1,16 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class SUBADDON {
+        addonRootClass = QUOTE(ADDON);
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"ace_tagging"};
+        units[] = {};
+        weapons[] = {};
+        // Optional. If this is 1, if any of requiredAddons[] entry is missing in your game the entire config will be ignored and return no error (but in rpt) so useful to make a compat Mod (Since Arma 3 2.14)
+        skipWhenMissingDependencies = 1;
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgTags.hpp"

--- a/addons/insignias/insignias_tagging/readme.md
+++ b/addons/insignias/insignias_tagging/readme.md
@@ -1,0 +1,7 @@
+# Insignias - Tagging
+
+Fügt TTT Insignien dem ACE-Tagging Framework hinzu.
+
+## Maintainer
+
+- Andx

--- a/addons/insignias/insignias_tagging/readme.md
+++ b/addons/insignias/insignias_tagging/readme.md
@@ -2,6 +2,19 @@
 
 Fügt TTT Insignien dem ACE-Tagging Framework hinzu.
 
+## Sprühdosen
+
+- Schwarz -> Schwarz, Grau
+- Rot -> Rod, Violett
+- Blau -> Blau
+- Gelb -> Gelb, Orange, Bronze
+- Grün -> Grün
+- Weiß -> Weiß, Silver, Platin
+
+## Referenzen
+
+<https://ace3.acemod.org/wiki/framework/tagging-framework>
+
 ## Maintainer
 
 - Andx

--- a/addons/insignias/insignias_tagging/script_component.hpp
+++ b/addons/insignias/insignias_tagging/script_component.hpp
@@ -1,0 +1,17 @@
+#define SUB_COMPONENT tagging
+#define SUB_COMPONENT_BEAUTIFIED Tagging
+#include "\z\ttt\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_BLANK
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_BLANK
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_BLANK
+#endif
+
+#include "\z\ttt\addons\main\script_macros.hpp"


### PR DESCRIPTION
# PULL REQUEST

**When merged this pull request will:**

- title
- TTT Farben sind so gut es geht auf die ACE Sprühdosen gemappt

## IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Remove {changes}`.
- Component folder has a README.md explaining the component.
