### PR TITLE
compat_rhs - Fix macro padding

### DIFF
--- a/addons/compat_rhs/CfgEventhandlers.hpp
+++ b/addons/compat_rhs/CfgEventhandlers.hpp
@@ -18,6 +18,6 @@ class Extended_PostInit_EventHandlers {
 
 class Extended_SlotItemChanged_Eventhandlers {
     class CAManBase {
-        GVAR(SlotItemChanged) = QUOTE( call FUNC(handleSlotItemChanged););
+        GVAR(SlotItemChanged) = QUOTE(call FUNC(handleSlotItemChanged););
     };
 };


### PR DESCRIPTION

# PULL REQUEST

**When merged this pull request will:**

- title

Removes Warning:
```
warning[PW3]: padding a macro argument
   ┌─ addons/compat_rhs/CfgEventhandlers.hpp:21:39
   │
21 │         GVAR(SlotItemChanged) = QUOTE( call FUNC(handleSlotItemChanged););
   │                                       ^ padding a macro argument
   │
   = note: padding a macro argument is likely unintended
   = note: occured in: `QUOTE` 
```

## IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Remove {changes}`.
