### PR TITLE
compat_cfg - Change `PROPREFIX`

### DIFF
--- a/addons/compat_cfp/$PBOPREFIX$
+++ b/addons/compat_cfp/$PBOPREFIX$
@@ -1,1 +1,1 @@
-z\ttt\addons\compat_cfp_vehicles
+z\ttt\addons\compat_cfp


### PR DESCRIPTION
# PULL REQUEST

**When merged this pull request will:**

- die Compoent war früher nur für die Vehicles gedacht, ist aber mittlerweile für alles in CFP, deswegen war der alte PBOPREFIX irreführend

## IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Remove {changes}`.
- Component folder has a README.md explaining the component.
