### PR TITLE
signalpanel - Add Setting for Buildtime

### DIFF
--- a/addons/signalpanel/functions/fnc_progressbarConstruct.sqf
+++ b/addons/signalpanel/functions/fnc_progressbarConstruct.sqf
@@ -24,7 +24,7 @@ if (_position isEqualTo []) exitWith {
 _target playMove "Acts_carFixingWheel";
 
 [
-    19,
+    GVAR(buildTime),
     [_target],
     {
         (_this select 0) params ["_target"];

--- a/addons/signalpanel/initSettings.inc.sqf
+++ b/addons/signalpanel/initSettings.inc.sqf
@@ -9,6 +9,15 @@
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(buildTime),
+    "SLIDER",
+    [LSTRING(settingBuildTime_name), LSTRING(settingBuildTime_description)],
+    [ELSTRING(main,TacticalTrainingTeam), LSTRING(SubCategory)],
+    [2, 60, 6, 0],
+    true
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(supportedBackpacks),
     "EDITBOX",
     [LSTRING(supportedBackpacks_displayName), LSTRING(allowedBackpacks_description)],

--- a/addons/signalpanel/readme.md
+++ b/addons/signalpanel/readme.md
@@ -2,7 +2,7 @@
 
 Eine Signalplane ist eine Möglichkeit einem Hubschrauber auch aus größerer Distanz optisch eine Landezone zu markieren.
 Mit dieser Erweiterung können bestimmte Rucksäcke eine große farbige Plane transportieren, die der Spieler dann auf und abbauen kann.
-Die Plane ist dabei weder an edn Spieler noch den Rucksacktypen gebunden. Der abbauende Spieler muss nur den richtigen Rucksack nutzen und derzeit nicht schon eine Plane transportieren.
+Die Plane ist dabei weder an den Spieler noch den Rucksacktypen gebunden. Der abbauende Spieler muss nur den richtigen Rucksack nutzen und derzeit nicht schon eine Plane transportieren.
 
 ## Hinweis
 
@@ -17,7 +17,8 @@ Am einfachsten passiert das in der `Loadout.sqf` des Spielers mittels:
 
 ```c++
 force ttt_signalpanel_enable = true;                                                //default: false;
-force ttt_signalpanel_supportedBackpacks = '["B_kitbag_rgr", "B_AssaultPack_rgr"]';   //default: [];
+force ttt_signalpanel_supportedBackpacks = '["B_kitbag_rgr", "B_AssaultPack_rgr"]';   //default: '[]';
+force ttt_signalpanel_buildTime = 19; //default: 6;
 ```
 
 ## Beispielbild

--- a/addons/signalpanel/readme.md
+++ b/addons/signalpanel/readme.md
@@ -2,7 +2,7 @@
 
 Eine Signalplane ist eine Möglichkeit einem Hubschrauber auch aus größerer Distanz optisch eine Landezone zu markieren.
 Mit dieser Erweiterung können bestimmte Rucksäcke eine große farbige Plane transportieren, die der Spieler dann auf und abbauen kann.
-Die Plane ist dabei weder an den Spieler noch den Rucksacktypen gebunden. Der abbauende Spieler muss nur den richtigen Rucksack nutzen und derzeit nicht schon eine Plane transportieren.
+Die Plane ist dabei nicht an den Spieler gebunden. Der abbauende Spieler muss nur den richtigen Rucksack nutzen und derzeit nicht schon eine Plane transportieren.
 
 ## Hinweis
 

--- a/addons/signalpanel/stringtable.xml
+++ b/addons/signalpanel/stringtable.xml
@@ -33,6 +33,14 @@
             <English>The panel was stowed into the backpack.</English>
             <German>"Die Plane wurde in den Rucksack gepackt."</German>
         </Key>
+        <Key ID="STR_ttt_Signalpanel_settingBuildTime_description">
+            <English>How many seconds does the player need to lay out the panel.</English>
+            <German>Wie viele Sekunden der Spieler braucht, um die Plane auszubreiten.</German>
+        </Key>
+        <Key ID="STR_ttt_Signalpanel_settingBuildTime_name">
+            <English>Buildtime</English>
+            <German>Bauzeit</German>
+        </Key>
         <Key ID="STR_ttt_Signalpanel_subcategory">
             <English>Signaling Panel</English>
             <German>Signalplane</German>


### PR DESCRIPTION

# PULL REQUEST

**When merged this pull request will:**

- fügt eine CBA-Einstellung hinzu um festzulegen wie lange ein Spieler braucht um die Signalplane auszulegen (Default: 6 Sekunden)
- Update Readme

## IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Remove {changes}`.
- Component folder has a README.md explaining the component.
