### PR TITLE
MPLS - Increase time after JIP to apply loadout

### DIFF
--- a/addons/mpls/XEH_postInit.sqf
+++ b/addons/mpls/XEH_postInit.sqf
@@ -42,13 +42,13 @@ if (didJIP) then {
     };
 
     // apply the last saved loadout to the player
-    // wait 5 seconds to account for any delay with loadouts assigned through onPlayerResawn.sqf
+    // wait 10 seconds to account for any delay with loadouts assigned through onPlayerRespawn.sqf
     [
         {
             params ["_player"];
             _player call FUNC(applyLoadout);
         },
         [ace_player],
-        5
+        10
     ] call CBA_fnc_waitAndExecute;
 };


### PR DESCRIPTION

# PULL REQUEST

**When merged this pull request will:**

- manchmal ist die Loadoutvergabe langsamer als das MPLS und überschreibt das gespeicherte Loadout -> Zeit erhöhen bis das MPLS loaodut vergeben wird

## IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Remove {changes}`.
- Component folder has a README.md explaining the component.
