### PR TITLE
Chat Commands - Add new component

### DIFF
--- a/addons/chatcommands/$PBOPREFIX$
+++ b/addons/chatcommands/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\ttt\addons\chatcommands

--- a/addons/chatcommands/CfgEventHandlers.hpp
+++ b/addons/chatcommands/CfgEventHandlers.hpp
@@ -1,0 +1,5 @@
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_SCRIPT(XEH_postInit));
+    };
+};

--- a/addons/chatcommands/XEH_postInit.sqf
+++ b/addons/chatcommands/XEH_postInit.sqf
@@ -1,0 +1,43 @@
+#include "script_component.hpp"
+
+// - Chat Commands
+// Basierend auf der Arbeit von Gruppe W 
+// https://gitlab.gruppe-w.de/Missionsbau/Framework/-/blob/master/addons/api/XEH_postInit.sqf?ref_type=heads
+
+// - Zeus chat command --------------------------------------------------------
+[QGVAR(giveZeus), {
+    params ["_unit"];
+    private _curator = (createGroup sideLogic) createUnit ["ModuleCurator_F", [0, 0, 0], [], 0, "CAN_COLLIDE"];
+    _curator setVariable ["Addons", 3, true];
+    _curator addCuratorEditableObjects [allMissionObjects "", true];
+    _unit assignCurator _curator;
+    INFO_1("Zeus assigned to %1",_unit);
+}] call CBA_fnc_addEventHandler;
+
+["zeus", {
+    systemChat "Zeus wird angefordert...";
+    [QGVAR(giveZeus), [player]] call CBA_fnc_serverEvent;
+}, "admin"] call CBA_fnc_registerChatCommand;
+
+ // - End mission chat command -------------------------------------------------
+[QGVAR(endMission), BIS_fnc_endMission] call CBA_fnc_addEventHandler;
+
+["endmission", {
+    params ["_ending"];
+    if (_ending == "") then {
+        [QGVAR(endMission), ["", true]] call CBA_fnc_globalEvent;
+    } else {
+        [QGVAR(endMission), [_ending, true]] call CBA_fnc_globalEvent;
+    };
+    INFO_1("Mission ended with ending: %1",_ending);
+}, "admin"] call CBA_fnc_registerChatCommand;
+
+["failmission", {
+    params ["_ending"];
+    if (_ending == "") then {
+        [QGVAR(endMission), ["loser", false]] call CBA_fnc_globalEvent;
+    } else {
+        [QGVAR(endMission), [_ending, false]] call CBA_fnc_globalEvent;
+    };
+    INFO_1("Mission ended with ending: %1",_ending);
+}, "admin"] call CBA_fnc_registerChatCommand;

--- a/addons/chatcommands/XEH_postInit.sqf
+++ b/addons/chatcommands/XEH_postInit.sqf
@@ -1,10 +1,10 @@
 #include "script_component.hpp"
 
-// - Chat Commands
+// Chat Commands
 // Basierend auf der Arbeit von Gruppe W 
 // https://gitlab.gruppe-w.de/Missionsbau/Framework/-/blob/master/addons/api/XEH_postInit.sqf?ref_type=heads
 
-// - Zeus chat command --------------------------------------------------------
+// Zeus chat command
 [QGVAR(giveZeus), {
     params ["_unit"];
     private _curator = (createGroup sideLogic) createUnit ["ModuleCurator_F", [0, 0, 0], [], 0, "CAN_COLLIDE"];
@@ -19,7 +19,7 @@
     [QGVAR(giveZeus), [player]] call CBA_fnc_serverEvent;
 }, "admin"] call CBA_fnc_registerChatCommand;
 
-// - End mission chat command -------------------------------------------------
+// End mission chat command 
 [QGVAR(endMission), BIS_fnc_endMission] call CBA_fnc_addEventHandler;
 
 ["endmission", {
@@ -42,7 +42,7 @@
     INFO_1("Mission ended with ending: %1",_ending);
 }, "admin"] call CBA_fnc_registerChatCommand;
 
-// - Tech Support chat command -----------------------------------------------
+// Tech Support chat command
 [QGVAR(techSupport), {
     params ["_unit"];
     GVAR(teleporter) = "ttt_Flag_Logo" createVehicleLocal [0,0,0]; //it's faster to create it far away from anyone at the corner of the map

--- a/addons/chatcommands/XEH_postInit.sqf
+++ b/addons/chatcommands/XEH_postInit.sqf
@@ -41,3 +41,18 @@
     };
     INFO_1("Mission ended with ending: %1",_ending);
 }, "admin"] call CBA_fnc_registerChatCommand;
+
+// - Tech Support chat command -----------------------------------------------
+[QGVAR(techSupport), {
+    params ["_unit"];
+    GVAR(teleporter) = "ttt_Flag_Logo" createVehicleLocal [0,0,0]; //its faster to create it far away from anyone
+    GVAR(teleporter) setPosATL (getPosATL _unit); //and then move it to its intended position
+    GVAR(teleporter) allowDamage false;
+    [GVAR(teleporter)] call EFUNC(teleport,addActions);
+
+    INFO_1("Teleporter created at %1",getPosATL GVAR(teleporter));
+}] call CBA_fnc_addEventHandler;
+
+["techsupport", {
+    [QGVAR(techSupport), [player]] call CBA_fnc_serverEvent;
+}, "admin"] call CBA_fnc_registerChatCommand;

--- a/addons/chatcommands/XEH_postInit.sqf
+++ b/addons/chatcommands/XEH_postInit.sqf
@@ -19,7 +19,7 @@
     [QGVAR(giveZeus), [player]] call CBA_fnc_serverEvent;
 }, "admin"] call CBA_fnc_registerChatCommand;
 
- // - End mission chat command -------------------------------------------------
+// - End mission chat command -------------------------------------------------
 [QGVAR(endMission), BIS_fnc_endMission] call CBA_fnc_addEventHandler;
 
 ["endmission", {
@@ -35,7 +35,7 @@
 ["failmission", {
     params ["_ending"];
     if (_ending == "") then {
-        [QGVAR(endMission), ["loser", false]] call CBA_fnc_globalEvent;
+        [QGVAR(endMission), ["", false]] call CBA_fnc_globalEvent;
     } else {
         [QGVAR(endMission), [_ending, false]] call CBA_fnc_globalEvent;
     };
@@ -45,7 +45,7 @@
 // - Tech Support chat command -----------------------------------------------
 [QGVAR(techSupport), {
     params ["_unit"];
-    GVAR(teleporter) = "ttt_Flag_Logo" createVehicleLocal [0,0,0]; //its faster to create it far away from anyone
+    GVAR(teleporter) = "ttt_Flag_Logo" createVehicleLocal [0,0,0]; //it's faster to create it far away from anyone at the corner of the map
     GVAR(teleporter) setPosATL (getPosATL _unit); //and then move it to its intended position
     GVAR(teleporter) allowDamage false;
     [GVAR(teleporter)] call EFUNC(teleport,addActions);

--- a/addons/chatcommands/config.cpp
+++ b/addons/chatcommands/config.cpp
@@ -1,0 +1,17 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"ttt_common"};
+        author = ECSTRING(main,TacticalTrainingTeam);
+        authors[] = {"Andx","BlauBaer"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgEventHandlers.hpp"

--- a/addons/chatcommands/config.cpp
+++ b/addons/chatcommands/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ttt_common"};
+        requiredAddons[] = {"ttt_common","ttt_teleport"};
         author = ECSTRING(main,TacticalTrainingTeam);
         authors[] = {"Andx","BlauBaer"};
         url = ECSTRING(main,URL);

--- a/addons/chatcommands/config.cpp
+++ b/addons/chatcommands/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ttt_common","ttt_teleport"};
+        requiredAddons[] = {"ttt_common","ttt_teleport","ttt_signs"};
         author = ECSTRING(main,TacticalTrainingTeam);
         authors[] = {"Andx","BlauBaer"};
         url = ECSTRING(main,URL);

--- a/addons/chatcommands/readme.md
+++ b/addons/chatcommands/readme.md
@@ -12,6 +12,10 @@ Andere Spieler sehen die Eingabe des Befehls nicht.
 
 `#endmission` / `#failmission` Beendet die Mission als Erfolg bzw. Fehlschlag.
 
+## Technicher Teleport
+
+`#techsupport` erzeugt an der eigenen Position einen Teleporter (TTT-Flagge), mit Aktionen für die Zuschauerkamera und den Tech.-Teleport.
+
 ## Maintainer
 
 - Andx

--- a/addons/chatcommands/readme.md
+++ b/addons/chatcommands/readme.md
@@ -1,0 +1,17 @@
+# Chat Commands
+
+Stellt Chat Befehle zur Verfügung um im Notfall die Mission zu beenden oder einen neuen Zeus festzulegen. Um den Chat in Arma 3 zu öffnen drücke die <kbd>-</kbd>-Taste. Die Befehle beginnen immer mit einem <kbd>#</kbd>. Für alle Befehle muss man Admin sein (entweder "voted" oder "logged").
+
+Andere Spieler sehen die Eingabe des Befehls nicht.
+
+## Zeus
+
+`#zeus` macht einen Selber zum Zeus
+
+## Mission beenden
+
+`#endmission` / `#failmission` Beendet die Mission als Erfolg bzw. Fehlschlag.
+
+## Maintainer
+
+- Andx

--- a/addons/chatcommands/script_component.hpp
+++ b/addons/chatcommands/script_component.hpp
@@ -1,0 +1,5 @@
+#define COMPONENT chatcommands
+#define COMPONENT_BEAUTIFIED Chat Commands
+
+#include "\z\ttt\addons\main\script_mod.hpp"
+#include "\z\ttt\addons\main\script_macros.hpp"


### PR DESCRIPTION
# PULL REQUEST

**When merged this pull request will:**

- title
- Fügt Chat Befehle hinzu für
  - Zeus werden (`#zeus`)
  - Mission erfolgeich beenden (`#endmission`)
  - Mission als Fehlschlag beenden (`#failmission`)
  - Tech. Teleport an eigener Position erstellen (`#techsupport`)
- für alle Befehle muss man Admin sein
- basiert auf der Arbeit von Grp W https://gitlab.gruppe-w.de/Missionsbau/Framework/-/blob/master/addons/api/XEH_postInit.sqf?ref_type=heads (GPL)

## IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Remove {changes}`.
- Component folder has a README.md explaining the component.
