### PR TITLE
MPLS - Improve Timers and Logging, Prevent HC from running it

### DIFF
--- a/addons/mpls/XEH_postInit.sqf
+++ b/addons/mpls/XEH_postInit.sqf
@@ -7,7 +7,7 @@ if (isServer) then {
             call FUNC(initSave);
         },
         [],
-        20
+        30
     ] call CBA_fnc_waitAndExecute;
 };
 
@@ -16,14 +16,14 @@ if (!hasInterface) exitWith {};
 
 // If the _first Loadout does not exist, create it
 [
-    {            
+    {
         params ["_player"];
         if (GVAR(loadoutNamespace) getVariable [([getPlayerUID _player, "_first"] joinString ""), []] isEqualTo []) then {
             GVAR(loadoutNamespace) setVariable [[getPlayerUID _player, "_first"] joinString "", [_player] call CBA_fnc_getLoadout, true]; //saves the very first loadout to the DB
         };
     },
     [ace_player],
-    5
+    30
 ] call CBA_fnc_waitAndExecute;
 
 // If player is JIP

--- a/addons/mpls/functions/fnc_applyLoadout.sqf
+++ b/addons/mpls/functions/fnc_applyLoadout.sqf
@@ -7,7 +7,7 @@
  * 0: Player <OBJECT>
  *
  * Return Value:
- * 0: Sucess 
+ * 0: Sucess
  *
  * Example:
  * [this] call ttt_mpls_fnc_applyLoadout
@@ -17,10 +17,14 @@
 
 params ["_player"];
 
+if (!hasInterface) exitWith {};
+
 if ((GVAR(loadoutNamespace) getVariable [(getPlayerUID _player),[]]) isEqualTo []) exitWith {false};
 
-[_player, GVAR(loadoutNamespace) getVariable (getPlayerUID _player)] call CBA_fnc_setLoadout;
+private _loadout =  GVAR(loadoutNamespace) getVariable (getPlayerUID _player);
 
-INFO_1("Saved Loadout found for player %1 ,applying ...",_player);
+[_player, _loadout] call CBA_fnc_setLoadout;
+
+INFO_2("Saved Loadout found for player %1, applying %2",_player,_loadout);
 
 true

--- a/addons/mpls/functions/fnc_saveLoadout.sqf
+++ b/addons/mpls/functions/fnc_saveLoadout.sqf
@@ -21,12 +21,16 @@ params [
     ["_uid", "", [""]]
     ];
 
+if (!hasInterface) exitWith {};
+
 if (_uid isEqualTo "") then {
     _uid = getPlayerUID _player;
 };
 
-GVAR(loadoutNamespace) setVariable [_uid, [_player] call CBA_fnc_getLoadout, true];
+private _loadout = [_player] call CBA_fnc_getLoadout;
 
-INFO_1("Loadout Saved for player %1",_player);
+GVAR(loadoutNamespace) setVariable [_uid, _loadout, true];
+
+INFO_2("Loadout Saved for player %1 is %2",_player,_loaodout);
 
 true


### PR DESCRIPTION
# PULL REQUEST

**When merged this pull request will:**

- erhöht Zeit bis zum ersten Speichern auf 30s (war 20s)
- erhöht Zeit bis das Anfangsloadout gespeichert wird auf 30s (war 5s)
- fügt Safeguard zu `saveLoadout` und `applyLoadout` damit diese nicht auf dem HC ausgeführt werden
- Verbessert Logging in `saveLoadout` und `applyLoadout`

## IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Remove {changes}`.
- Component folder has a README.md explaining the component.
