### PR TITLE
Chat Commands - Remove `#zeus` command

### DIFF
--- a/addons/chatcommands/XEH_postInit.sqf
+++ b/addons/chatcommands/XEH_postInit.sqf
@@ -4,21 +4,6 @@
 // Basierend auf der Arbeit von Gruppe W 
 // https://gitlab.gruppe-w.de/Missionsbau/Framework/-/blob/master/addons/api/XEH_postInit.sqf?ref_type=heads
 
-// Zeus chat command
-[QGVAR(giveZeus), {
-    params ["_unit"];
-    private _curator = (createGroup sideLogic) createUnit ["ModuleCurator_F", [0, 0, 0], [], 0, "CAN_COLLIDE"];
-    _curator setVariable ["Addons", 3, true];
-    _curator addCuratorEditableObjects [allMissionObjects "", true];
-    _unit assignCurator _curator;
-    INFO_1("Zeus assigned to %1",_unit);
-}] call CBA_fnc_addEventHandler;
-
-["zeus", {
-    systemChat "Zeus wird angefordert...";
-    [QGVAR(giveZeus), [player]] call CBA_fnc_serverEvent;
-}, "admin"] call CBA_fnc_registerChatCommand;
-
 // End mission chat command 
 [QGVAR(endMission), BIS_fnc_endMission] call CBA_fnc_addEventHandler;
 

--- a/addons/chatcommands/readme.md
+++ b/addons/chatcommands/readme.md
@@ -1,6 +1,6 @@
 # Chat Commands
 
-Stellt Chat Befehle zur Verfügung um im Notfall die Mission zu beenden oder einen neuen Zeus festzulegen
+Stellt Chat Befehle zur Verfügung um im Notfall die Mission zu beenden.
 
 ## Maintainer
 


### PR DESCRIPTION
# PULL REQUEST

**When merged this pull request will:**

- der gleiche Command ist in Metis Enhanced (https://github.com/Metis-Team/mts_enhanced/blob/master/addons/common/functions/fnc_addChatCommands.sqf)

## IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Remove {changes}`.
- Component folder has a README.md explaining the component.
