### PR TITLE
Chat Commands - Change `requiredAddons` to load after Metis-Enhanced

### DIFF
--- a/addons/chatcommands/config.cpp
+++ b/addons/chatcommands/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"ttt_common","ttt_teleport","ttt_signs"};
+        requiredAddons[] = {"ttt_common","ttt_teleport","ttt_signs","mts_common"};
         author = ECSTRING(main,TacticalTrainingTeam);
         authors[] = {"Andx","BlauBaer"};
         url = ECSTRING(main,URL);


### PR DESCRIPTION

# PULL REQUEST

**When merged this pull request will:**

- title
- diese Mod und Metis-Enhanced definieren beide den `#zeus` Chat Command - wenn wir Metis Enhanced als Abhängigkeit hier reinschrieben, stellen wir sicher, dass die TTT-Mod **nach** Metis Enhanced geladen wird und unsere Version des Command deren überschreibt

## IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Remove {changes}`.
- Component folder has a README.md explaining the component.
