### PR TITLE
Common - Fix Zeusname in Composition

### DIFF
--- a/addons/common/compositions/basisModule/composition.sqe
+++ b/addons/common/compositions/basisModule/composition.sqe
@@ -574,7 +574,7 @@ class items
 				class Attributes
 				{
 					name="zeus_1";
-					description="Zeus@Zeus";
+					description="Zeus";
 					isPlayable=1;
 				};
 				id=21;


### PR DESCRIPTION
# PULL REQUEST

**When merged this pull request will:**

- title
- beim Auslesen der Slotliste fürs Discord tauchte der zweite Zeus auf als "Zeus@Zeus"

## IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Remove {changes}`.
- Component folder has a README.md explaining the component.
