### PR TITLE
MPLS - Improve by applying loadout only in the same slot

### DIFF
--- a/addons/mpls/XEH_postInit.sqf
+++ b/addons/mpls/XEH_postInit.sqf
@@ -24,7 +24,7 @@ if (!hasInterface) exitWith {};
         };
 
         if (GVAR(loadoutNamespace) getVariable [([getPlayerUID _player, "_slot"] joinString ""), ""] isEqualTo "") then {
-            GVAR(loadoutNamespace) setVariable [[getPlayerUID _player, "_slot"] joinString "", typeOf _player];
+            GVAR(loadoutNamespace) setVariable [[getPlayerUID _player, "_slot"] joinString "", roleDescription _player]; //roleDescription is unique, alternative would be typeOf _player
         };
     },
     [ace_player],
@@ -52,7 +52,7 @@ if (didJIP) then {
         {
             params ["_player"];
 
-            private _currentSlot = typeOf _player;
+            private _currentSlot = roleDescription _player; //roleDescription is unique, alternative would be typeOf _player
             private _oldSlot = GVAR(loadoutNamespace) getVariable [([getPlayerUID _player, "_slot"] joinString ""), ""];
 
             if (_currentSlot isEqualTo _oldSlot) then {


### PR DESCRIPTION
# PULL REQUEST

**When merged this pull request will:**

- speichert den Slot über `roleDescription` im selben Namespace wie die loadout
- bei JIP wird überprüft ob die aktuelle Role description identischt zur gespeicherten ist, wenn ja wir das vom System gespeicherte loadout geladen

Gedanken:
- `roleDescription` sollte wegen Slotbot Unique innerhalb einer Mission sein `#Nummer Slotname` - alternative wäre `typeOf` zu nutzen um z.B. `B_Soldier_F` zubekommen, dann könnten man zwischen gleichen Slots wechseln und bekommt das gespeicherte Loadout, sofern der MB jede Rolle mit einem eigenen Einheitentyp platziert hat

## IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Remove {changes}`.
- Component folder has a README.md explaining the component.
