### PR TITLE
Compat RHS - Fix `No entry 'bin\config.bin/CfgPatches/ttt_compat_rhs_usaf.units' `

### DIFF
--- a/addons/compat_rhs/afrf_equipment_balance_compat/config.cpp
+++ b/addons/compat_rhs/afrf_equipment_balance_compat/config.cpp
@@ -19,7 +19,7 @@ class CfgPatches {
             "rhs_c_troops"
         };
         // List of objects (CfgVehicles classes) contained in the addon. Important also for Zeus content (units and groups) unlocking.
-        vehicles[] = {
+        units[] = {
             //PACKS
             "rhs_assault_umbts",
             "rhs_assault_umbts_engineer",

--- a/addons/compat_rhs/gref_equipment_balance_compat/config.cpp
+++ b/addons/compat_rhs/gref_equipment_balance_compat/config.cpp
@@ -19,7 +19,7 @@ class CfgPatches {
             "rhsgref_c_troops",
         };
         // List of weapons (CfgWeapons classes) contained in the addon.
-        vehicles[] = {
+        units[] = {
             //PACKS
             "rhsgref_cdf_backpack_mg",
             "rhsgref_cdf_backpack_mg2",

--- a/addons/compat_rhs/usaf_equipment_balance_compat/config.cpp
+++ b/addons/compat_rhs/usaf_equipment_balance_compat/config.cpp
@@ -18,7 +18,7 @@ class CfgPatches {
             "rhsusf_c_troops",
         };
         // List of objects (CfgVehicles classes) contained in the addon. Important also for Zeus content (units and groups) unlocking.
-        vehicles[] = {
+        units[] = {
             //PACKS
             "rhsusf_assault_eagleaiii_ocp",
             "rhsusf_assault_eagleaiii_ocp_engineer",


### PR DESCRIPTION

# PULL REQUEST

**When merged this pull request will:**

- fix
```
22:55:44 Warning Message: No entry 'bin\config.bin/CfgPatches/ttt_compat_rhs_usaf.units'
22:55:44 Warning Message: No entry 'bin\config.bin/CfgPatches/ttt_compat_rhs_afrf.units'
22:55:44 Warning Message: No entry 'bin\config.bin/CfgPatches/ttt_compat_rhs_gref.units'
22:55:44 Warning Message: No entry 'bin\config.bin/CfgPatches/ttt_compat_rhs_usaf.units'
22:55:44 Warning Message: No entry 'bin\config.bin/CfgPatches/ttt_compat_rhs_afrf.units'
22:55:44 Warning Message: No entry 'bin\config.bin/CfgPatches/ttt_compat_rhs_gref.units'
22:55:44 Warning Message: No entry 'bin\config.bin/CfgPatches/ttt_compat_rhs_usaf.units'
22:55:44 Warning Message: No entry 'bin\config.bin/CfgPatches/ttt_compat_rhs_afrf.units'
22:55:44 Warning Message: No entry 'bin\config.bin/CfgPatches/ttt_compat_rhs_gref.units'
22:55:44 Warning Message: No entry 'bin\config.bin/CfgPatches/ttt_compat_rhs_usaf.units'
22:55:44 Warning Message: No entry 'bin\config.bin/CfgPatches/ttt_compat_rhs_afrf.units'
22:55:44 Warning Message: No entry 'bin\config.bin/CfgPatches/ttt_compat_rhs_gref.units'
```

## IMPORTANT

- [Development Guidelines](https://ace3.acemod.org/wiki/development/) are read, understood and applied.
- Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Remove {changes}`.
- Component folder has a README.md explaining the component.
